### PR TITLE
Pattern Matching in pattern proc

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,10 @@
+# ChangeLog
+
+## Unreleased
+### Added
+ - Pattern Matching in pattern proc
+
+## 1.0.0
+### Added
+ - Released!
+ - Ruby 2.7.0 support

--- a/README.md
+++ b/README.md
@@ -47,6 +47,28 @@ fizzbuzz(5) # => :Buzz
 fizzbuzz(15) # => :FizzBuzz
 ```
 
+You can use normal pattern matching in `pattern` method.
+
+```ruby
+module Response
+  extend ActivePattern::Context[Hash]
+  OK = pattern { self in { status: :ok, body: body }; [body] }
+  NG = pattern { self in { status: :ng, message: message }; [message] }
+end
+
+def print_response(response)
+  case response
+  in OK[body]; puts body
+  in NG[message]; puts message
+  else; puts 'no match'
+  end
+end
+
+print_response(status: :ok, body: 'Wow!') # => Wow!
+print_response(status: :ng, message: 'Oops!') #=> Oops!
+print_response(status: :unknown) #=> no match
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/active_pattern/pattern_object.rb
+++ b/lib/active_pattern/pattern_object.rb
@@ -17,6 +17,8 @@ module ActivePattern
         $_ACTIVE_PATTERN_MATCHES = nil
         match_result
       end
+    rescue NoMatchingPatternError
+      false
     end
   end
 end

--- a/spec/active_pattern/context_spec.rb
+++ b/spec/active_pattern/context_spec.rb
@@ -98,4 +98,35 @@ RSpec.describe ActivePattern::Context do
       end
     end
   end
+
+  describe 'inline pattern matching' do
+    module Response
+      extend ActivePattern::Context[Hash]
+      OK = pattern { self in { status: :ok, body: body }; [body] }
+      NG = pattern { self in { status: :ng, message: message }; [message] }
+    end
+
+    it 'does not match with empty hash' do
+      case {}
+      in Response::OK[_]; fail
+      in Response::NG[_]; fail
+      else; true
+      end
+    end
+
+    it 'match with ok and ng response hash' do
+      case { status: :ok, body: 'body' }
+      in Response::OK[body]
+        expect(body).to eq('body')
+      else; fail
+      end
+
+      case { status: :ng, message: 'message' }
+      in Response::OK[_]; fail
+      in Response::NG[message]
+        expect(message).to eq('message')
+      else; fail
+      end
+    end
+  end
 end


### PR DESCRIPTION
The Pattern matching is useful also active patten proc.
But it raise NoMatchingPatternError when proc is invoked.

This PR make that case only fail matching, not raise error.